### PR TITLE
Fixed NavigationActivity.java

### DIFF
--- a/app/src/main/java/com/example/welcome/cosmos_360/NavigationActivity.java
+++ b/app/src/main/java/com/example/welcome/cosmos_360/NavigationActivity.java
@@ -59,6 +59,7 @@ public class NavigationActivity extends AppCompatActivity {
     private void setFragment(android.support.v4.app.Fragment fragment){
         android.support.v4.app.FragmentTransaction fragmentTransaction = getSupportFragmentManager().beginTransaction();
         fragmentTransaction.replace(R.id.main_frame, fragment);
+        fragmentTransaction.addToBackStack(null);
         fragmentTransaction.commit();
     }
 }


### PR DESCRIPTION
You just had to clear the back stack actually because the Transactions of the Fragment are actually getting added/replaced before you call commit which would lead to a crash.  Here take a look at this accepted answer in Stack Overflow you will understand what  is the issue- https://stackoverflow.com/questions/22984950/what-is-the-meaning-of-addtobackstack-with-null-parameter

Long Story short:- Just add this line to your NavigationActivity.java file-         `fragmentTransaction.addToBackStack(null);`
You can take a look at the changed files on Github itself and then merge it also. Your call. :)